### PR TITLE
aws path style access

### DIFF
--- a/docs/docs/07-data-storage.md
+++ b/docs/docs/07-data-storage.md
@@ -22,6 +22,7 @@ The basic steps to configure S3 are:
 | `aws-s3.region` | Your AWS region (e.g. `us-east-1`). |
 | `aws-s3.bucketName` | Your S3 bucket name. |
 | `aws-s3.endpoint` | Your custom S3-compatible endpoint. |
+| `aws-s3.pathStyleAccess` | Enables aws sdk path style access. |
 
 Alternatively, you can leave the `aws-s3.accessKeyId` and `aws-s3.secretAccessKey` parameters unset,
 and the on-premises installation will use the "Default Credential Provider Chain" to search your environment for the credentials, as described at

--- a/src/main/java/com/structurizr/onpremises/component/review/AmazonWebServicesS3ReviewDao.java
+++ b/src/main/java/com/structurizr/onpremises/component/review/AmazonWebServicesS3ReviewDao.java
@@ -29,6 +29,7 @@ class AmazonWebServicesS3ReviewDao implements ReviewDao {
     static final String REGION_PROPERTY = "aws-s3.region";
     static final String BUCKET_NAME_PROPERTY = "aws-s3.bucketName";
     static final String ENDPOINT_PROPERTY = "aws-s3.endpoint";
+    static final String PATH_STYLE_ACCESS_PROPERTY = "aws-s3.pathStyleAccess";
 
     private static final String TYPE_TAG = "type";
     private static final String IMAGE_TYPE = "image";
@@ -41,15 +42,18 @@ class AmazonWebServicesS3ReviewDao implements ReviewDao {
     private final String region;
     private final String bucketName;
     private final String endpoint;
+    private final Boolean pathStyleAccessEnabled;
 
     private final AmazonS3 amazonS3;
 
-    AmazonWebServicesS3ReviewDao(String accessKeyId, String secretAccessKey, String region, String bucketName, String endpoint) {
+    AmazonWebServicesS3ReviewDao(String accessKeyId, String secretAccessKey, String region, String bucketName, String endpoint,
+            Boolean pathStyleAccessEnabled) {
         this.accessKeyId = accessKeyId;
         this.secretAccessKey = secretAccessKey;
         this.region = region;
         this.bucketName = bucketName;
         this.endpoint = endpoint;
+        this.pathStyleAccessEnabled = pathStyleAccessEnabled;
 
         this.amazonS3 = createAmazonS3Client();
     }
@@ -59,7 +63,7 @@ class AmazonWebServicesS3ReviewDao implements ReviewDao {
             log.debug("Creating AWS client with credentials from structurizr.properties file");
             BasicAWSCredentials credentials = new BasicAWSCredentials(accessKeyId, secretAccessKey);
             if (!StringUtils.isNullOrEmpty(endpoint)) {
-                return AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(credentials)).withEndpointConfiguration(new AmazonS3ClientBuilder.EndpointConfiguration(endpoint, region)).build();
+                return AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(credentials)).withEndpointConfiguration(new AmazonS3ClientBuilder.EndpointConfiguration(endpoint, region)).withPathStyleAccessEnabled(pathStyleAccessEnabled).build();
             }
             return AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(credentials)).withRegion(region).build();
         } else {

--- a/src/main/java/com/structurizr/onpremises/component/review/ReviewComponentImpl.java
+++ b/src/main/java/com/structurizr/onpremises/component/review/ReviewComponentImpl.java
@@ -39,8 +39,9 @@ class ReviewComponentImpl implements ReviewComponent {
             String region = Configuration.getConfigurationParameterFromStructurizrPropertiesFile(AmazonWebServicesS3ReviewDao.REGION_PROPERTY, "");
             String bucketName = Configuration.getConfigurationParameterFromStructurizrPropertiesFile(AmazonWebServicesS3ReviewDao.BUCKET_NAME_PROPERTY, "");
             String endpoint = Configuration.getConfigurationParameterFromStructurizrPropertiesFile(AmazonWebServicesS3ReviewDao.ENDPOINT_PROPERTY, "");
+            Boolean pathAccessEnabled = Boolean.parseBoolean(Configuration.getConfigurationParameterFromStructurizrPropertiesFile(AmazonWebServicesS3ReviewDao.PATH_STYLE_ACCESS_PROPERTY, "false"));
 
-            this.reviewDao = new AmazonWebServicesS3ReviewDao(accessKeyId, secretAccessKey, region, bucketName, endpoint);
+            this.reviewDao = new AmazonWebServicesS3ReviewDao(accessKeyId, secretAccessKey, region, bucketName, endpoint, pathAccessEnabled);
         } else {
             this.reviewDao = new FileSystemReviewDao();
         }

--- a/src/main/java/com/structurizr/onpremises/component/workspace/AmazonWebServicesS3WorkspaceDao.java
+++ b/src/main/java/com/structurizr/onpremises/component/workspace/AmazonWebServicesS3WorkspaceDao.java
@@ -28,6 +28,7 @@ public class AmazonWebServicesS3WorkspaceDao extends AbstractWorkspaceDao {
     static final String REGION_PROPERTY = "aws-s3.region";
     static final String BUCKET_NAME_PROPERTY = "aws-s3.bucketName";
     static final String ENDPOINT_PROPERTY = "aws-s3.endpoint";
+    static final String PATH_STYLE_ACCESS_PROPERTY = "aws-s3.pathStyleAccess";
 
     private static final String WORKSPACE_PROPERTIES_FILENAME = "workspace.properties";
     private static final String WORKSPACE_CONTENT_FILENAME = "workspace.json";
@@ -41,16 +42,18 @@ public class AmazonWebServicesS3WorkspaceDao extends AbstractWorkspaceDao {
     private final String region;
     private final String bucketName;
     private final String endpoint;
+    private final Boolean pathStyleAccessEnabled;
 
     private final AmazonS3 amazonS3;
 
     AmazonWebServicesS3WorkspaceDao(String accessKeyId, String secretAccessKey, String region, String bucketName,
-            String endpoint) {
+            String endpoint, Boolean pathStyleAccessEnabled) {
         this.accessKeyId = accessKeyId;
         this.secretAccessKey = secretAccessKey;
         this.region = region;
         this.bucketName = bucketName;
         this.endpoint = endpoint;
+        this.pathStyleAccessEnabled = pathStyleAccessEnabled;
 
         this.amazonS3 = createAmazonS3Client();
     }
@@ -60,7 +63,7 @@ public class AmazonWebServicesS3WorkspaceDao extends AbstractWorkspaceDao {
             log.debug("Creating AWS client with credentials from structurizr.properties file");
             BasicAWSCredentials credentials = new BasicAWSCredentials(accessKeyId, secretAccessKey);
             if (!StringUtils.isNullOrEmpty(endpoint)) {
-                return AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(credentials)).withEndpointConfiguration(new AmazonS3ClientBuilder.EndpointConfiguration(endpoint, region)).build();
+                return AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(credentials)).withEndpointConfiguration(new AmazonS3ClientBuilder.EndpointConfiguration(endpoint, region)).withPathStyleAccessEnabled(pathStyleAccessEnabled).build();
             }
             return AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(credentials)).withRegion(region).build();
         } else {

--- a/src/main/java/com/structurizr/onpremises/component/workspace/WorkspaceComponentImpl.java
+++ b/src/main/java/com/structurizr/onpremises/component/workspace/WorkspaceComponentImpl.java
@@ -47,8 +47,9 @@ public class WorkspaceComponentImpl implements WorkspaceComponent {
             String region = Configuration.getConfigurationParameterFromStructurizrPropertiesFile(AmazonWebServicesS3WorkspaceDao.REGION_PROPERTY, "");
             String bucketName = Configuration.getConfigurationParameterFromStructurizrPropertiesFile(AmazonWebServicesS3WorkspaceDao.BUCKET_NAME_PROPERTY, "");
             String endpoint = Configuration.getConfigurationParameterFromStructurizrPropertiesFile(AmazonWebServicesS3WorkspaceDao.ENDPOINT_PROPERTY, "");
+            Boolean pathAccessEnabled = Boolean.parseBoolean(Configuration.getConfigurationParameterFromStructurizrPropertiesFile(AmazonWebServicesS3WorkspaceDao.PATH_STYLE_ACCESS_PROPERTY, "false"));
 
-            this.workspaceDao = new AmazonWebServicesS3WorkspaceDao(accessKeyId, secretAccessKey, region, bucketName, endpoint);
+            this.workspaceDao = new AmazonWebServicesS3WorkspaceDao(accessKeyId, secretAccessKey, region, bucketName, endpoint,pathAccessEnabled);
         } else {
             this.workspaceDao = new FileSystemWorkspaceDao(Configuration.getInstance().getDataDirectory());
         }


### PR DESCRIPTION
While trying to connect to minio instead of aws s3 I've got this in logs:

`Caused by: com.amazonaws.SdkClientException: Unable to execute HTTP request: structurizr.minio`

I looked up on some docs and looks like withPathStyleAccess set to true fixes that issue and I can use structurizr with minio.
aws-s3.pathStyleAccess with default set to false is added to properties in this pr so it won't change default behavior.