### PR TITLE
Allow multiple environment variables to be substituted in config value

### DIFF
--- a/structurizr-onpremises/src/main/java/com/structurizr/onpremises/util/ConfigLookup.java
+++ b/structurizr-onpremises/src/main/java/com/structurizr/onpremises/util/ConfigLookup.java
@@ -11,6 +11,7 @@ public class ConfigLookup {
     public static final String DATA_DIRECTORY_SYSTEM_PROPERTY_NAME = "structurizr.dataDirectory";
     private static final String DATA_DIRECTORY_ENVIRONMENT_VARIABLE_NAME = "STRUCTURIZR_DATA_DIRECTORY";
     private static final String DEFAULT_DATA_DIRECTORY_PATH = "/usr/local/structurizr";
+    private static Pattern ENV_VAR_PATTERN = Pattern.compile("\\$\\{([\\w]*)\\}");
 
     public static String getDataDirectoryLocation() {
         return getConfigurationParameter(DATA_DIRECTORY_SYSTEM_PROPERTY_NAME, DATA_DIRECTORY_ENVIRONMENT_VARIABLE_NAME, null, DEFAULT_DATA_DIRECTORY_PATH);
@@ -70,13 +71,10 @@ public class ConfigLookup {
             }
         }
 
-        // translate ${...} into a value from the named environment variable
-        // (this mirrors what Spring does via the property placeholders)
+        // translate all ${...} within a string into a value, substituting any
+        // environment variables along the way
         if (value != null) {
-            if (value.startsWith("${") && value.endsWith("}")) {
-                String environmentVariableName = value.substring(2, value.length()-1);
-                value = System.getenv(environmentVariableName);
-            }
+            value = getValueFromEnvironmentVariables(value);
         }
 
         if (value == null) {
@@ -86,4 +84,24 @@ public class ConfigLookup {
         return value;
     }
 
+    private static String getValueFromEnvironmentVariables(String original)
+    {
+        Matcher matcher = ENV_VAR_PATTERN.matcher(original);
+        
+        int lastIndex = 0;
+        StringBuilder output = new StringBuilder();
+        while(matcher.find())
+        {
+            output.append(original, lastIndex, matcher.start())
+                .append(System.getenv(matcher.group(1)));
+
+            lastIndex = matcher.end();
+        }
+        
+        if (lastIndex < original.length()) {
+            output.append(original, lastIndex, original.length());
+        }
+        
+        return output.toString();
+    }
 }


### PR DESCRIPTION
This change should support using environment variable within the value string:

For example, in my k8s pod, I have some environment variables and I want to construct the URL like so:

```
structurizr.url=https://${SUBDOMAIN}.{ROOT_URL}
```