### PR TITLE
Add CSRF protection to workspace settings forms

### DIFF
--- a/structurizr-onpremises/src/main/java/com/structurizr/onpremises/web/security/CsrfSecurityRequestMatcher.java
+++ b/structurizr-onpremises/src/main/java/com/structurizr/onpremises/web/security/CsrfSecurityRequestMatcher.java
@@ -14,7 +14,7 @@ public class CsrfSecurityRequestMatcher implements RequestMatcher {
             String uri = request.getRequestURI();
 
             if (
-                    uri.startsWith("/login")
+                    uri.startsWith("/login") || uri.startsWith("/workspace")
             ) {
                 return true;
             }

--- a/structurizr-onpremises/src/main/webapp/WEB-INF/views/images.jsp
+++ b/structurizr-onpremises/src/main/webapp/WEB-INF/views/images.jsp
@@ -32,6 +32,7 @@
         <c:if test="${workspace.editable}">
         <div class="centered">
             <form id="deleteImagesForm" class="form-inline small centered" style="display: inline-block; margin-bottom: 5px" action="/workspace/${workspace.id}/images/delete" method="post">
+                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
                 <button class="btn btn-default" type="submit" name="action" value="delete" title="Delete published images"><img src="${structurizrConfiguration.cdnUrl}/bootstrap-icons/trash3.svg" class="icon-btn" /> Delete published images</button>
             </form>
         </div>

--- a/structurizr-onpremises/src/main/webapp/WEB-INF/views/users.jsp
+++ b/structurizr-onpremises/src/main/webapp/WEB-INF/views/users.jsp
@@ -47,6 +47,7 @@
         <c:choose>
             <c:when test="${workspace.editable}">
             <form action="/workspace/${workspace.id}/users" method="post">
+                <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
 
                 <div class="row">
                     <div class="col-sm-6">

--- a/structurizr-onpremises/src/main/webapp/WEB-INF/views/workspace-settings.jsp
+++ b/structurizr-onpremises/src/main/webapp/WEB-INF/views/workspace-settings.jsp
@@ -82,12 +82,14 @@
                                 <c:when test="${workspace.publicWorkspace}">
                                     <form id="privateWorkspaceForm" class="form-inline small centered" style="display: inline-block; margin-bottom: 5px" action="/workspace/${workspace.id}/private" method="post">
                                         <input type="hidden" name="workspaceId" value="${workspace.id}" />
+                                        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
                                         <button class="btn btn-default small" type="submit" name="action" value="private" title="Make workspace private"><img src="/static/bootstrap-icons/lock.svg" class="icon-btn" /> Make private</button>
                                     </form>
                                 </c:when>
                                 <c:otherwise>
                                     <form id="publicWorkspaceForm" class="form-inline small centered" style="display: inline-block; margin-bottom: 5px" action="/workspace/${workspace.id}/public" method="post">
                                         <input type="hidden" name="workspaceId" value="${workspace.id}" />
+                                        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
                                         <button class="btn btn-default small" type="submit" name="action" value="public" title="Make workspace public"><img src="/static/bootstrap-icons/unlock.svg" class="icon-btn" /> Make public</button>
                                     </form>
                                 </c:otherwise>
@@ -110,12 +112,14 @@
                                 <c:when test="${not empty workspace.sharingToken}">
                                     <form id="unshareWorkspaceForm" class="form-inline small centered" style="display: inline-block; margin-bottom: 5px" action="/workspace/${workspace.id}/unshare" method="post">
                                         <input type="hidden" name="workspaceId" value="${workspace.id}" />
+                                        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
                                         <button class="btn btn-default small" type="submit" name="action" value="unshare" title="Disable sharing link"><img src="/static/bootstrap-icons/link.svg" class="icon-btn" /> Disable sharing link</button>
                                     </form>
                                 </c:when>
                                 <c:otherwise>
                                     <form id="shareWorkspaceForm" class="form-inline small centered" style="display: inline-block; margin-bottom: 5px" action="/workspace/${workspace.id}/share" method="post">
                                         <input type="hidden" name="workspaceId" value="${workspace.id}" />
+                                        <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
                                         <button class="btn btn-default small" type="submit" name="action" value="share" title="Enable sharing link"><img src="/static/bootstrap-icons/link.svg" class="icon-btn" /> Enable sharing link</button>
                                     </form>
                                 </c:otherwise>
@@ -135,6 +139,7 @@
                         <button id="exportWorkspaceButton" class="btn btn-default small" title="Export workspace as JSON"><img src="${structurizrConfiguration.cdnUrl}/bootstrap-icons/filetype-json.svg" class="icon-btn" /> Export workspace</button>
                         <form id="deleteWorkspaceForm" class="form-inline small centered" style="display: inline-block; margin-bottom: 5px" action="/workspace/${workspace.id}/delete" method="post">
                             <input type="hidden" name="workspaceId" value="${workspace.id}" />
+                            <input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}" />
                             <button class="btn btn-danger small" type="submit" name="action" value="remove" title="Delete workspace"><img src="/static/bootstrap-icons/folder-x.svg" class="icon-white icon-btn" /> Delete workspace</button>
                         </form>
                     </c:if>


### PR DESCRIPTION
### Problem

Forms that change workspace settings are vulnerable to CSRF. A successful CSRF attack can lead to changing workspace user access list and to making private workspaces public. 

The vulnerability can be reproduced on the form for changing user access by following these steps:

1. Copy the following code and save it in a new html file: 
```html
<html>
  <body>
    <form action="http://localhost:8080/workspace/1/users" method="POST">
      <input type="hidden" name="writeUsers" value="structurizr&#13;&#10;csrf&#45;write&#64;gmail&#46;com&#13;&#10;" />
      <input type="hidden" name="readUsers" value="csrf&#45;read&#64;gmail&#46;com&#13;&#10;" />
      <input type="submit" value="Submit request" />
    </form>
    <script>
      history.pushState('', '', '/');
      document.forms[0].submit();
    </script>
  </body>
</html>
```
2. Change the workspace ID number in form `action` from 1 to an ID number of an existing workspace. 
3. Open the html file in a browser that's already authenticated to structurizr and click the submit button.
4. Note how the list of users that have access to the workspace has been updated. 

### Fix

The changes in the pull request add CSRF protection to seven forms. 

I built the code locally and tested the fix to make sure it works. 