### PR TITLE
Workspace Banner & Username Access Logs

### DIFF
--- a/structurizr-onpremises/src/main/java/com/structurizr/onpremises/web/security/AuthenticationSuccessHandler.java
+++ b/structurizr-onpremises/src/main/java/com/structurizr/onpremises/web/security/AuthenticationSuccessHandler.java
@@ -26,6 +26,8 @@ public class AuthenticationSuccessHandler extends SavedRequestAwareAuthenticatio
         User user = SecurityUtils.getUser(authentication);
         log.info(user.getUsername() + " successfully authenticated");
 
+	request.getSession().setAttribute("username", user.getUsername());
+
         if (user.getAuthenticationMethod() == AuthenticationMethod.LOCAL) {
             Cookie cookie = new Cookie("structurizr.username", user.getUsername());
             cookie.setSecure(true);

--- a/structurizr-onpremises/src/main/webapp/WEB-INF/fragments/prelude.jspf
+++ b/structurizr-onpremises/src/main/webapp/WEB-INF/fragments/prelude.jspf
@@ -34,9 +34,31 @@
     <script src="${structurizrConfiguration.cdnUrl}/js/bootstrap-3.3.7.min.js"></script>
     <script type="text/javascript" src="${structurizrConfiguration.cdnUrl}/js/structurizr${structurizrConfiguration.versionSuffix}.js"></script>
     <script type="text/javascript" src="${structurizrConfiguration.cdnUrl}/js/structurizr-util${structurizrConfiguration.versionSuffix}.js"></script>
+
+    <style>
+    	.banner {
+        	background-color: #1168BD;
+                color: white;
+                text-align: center;
+                padding: 5px;
+         }
+         .banner:empty {
+                display: none;
+         }
+    </style>
+
+    <script nonce="${scriptNonce}">
+         function setBanner() {
+                if (structurizr?.workspace?.getJson()?.properties?.banner) {
+                	document.getElementById('marking').innerHTML = structurizr.workspace.getJson().properties.banner.toUpperCase()
+                }
+          }
+    </script>
+
 </head>
 
 <body>
+    <div id='marking' class="banner"></div>
 
     <c:choose>
     <c:when test="${showHeader eq true}">


### PR DESCRIPTION
This PR adds two features:
1. It adds the username (regardless of file or saml auth) to the session such that it can be output into tomcat access logs
2. It adds a page banner (defined in the workspace properties of the DSL) to the top of the workspace pages of the UI

This PR is complementary to a PR of the same name in structurizr-ui.