### PR TITLE
Fixes getWorkspaceIds when S3 return is too big

### DIFF
--- a/structurizr-onpremises/src/main/java/com/structurizr/onpremises/component/workspace/AmazonWebServicesS3WorkspaceDao.java
+++ b/structurizr-onpremises/src/main/java/com/structurizr/onpremises/component/workspace/AmazonWebServicesS3WorkspaceDao.java
@@ -256,7 +256,16 @@ public class AmazonWebServicesS3WorkspaceDao extends AbstractWorkspaceDao {
 
         try {
             String folderKey = getBaseObjectName();
-            for (S3ObjectSummary file : amazonS3.listObjects(bucketName, folderKey).getObjectSummaries()) {
+
+            ObjectListing listing = amazonS3.listObjects(bucketName, folderKey);
+            List<S3ObjectSummary> files = listing.getObjectSummaries();
+
+            while (listing.isTruncated()) {
+                listing = amazonS3.listNextBatchOfObjects(listing);
+                files.addAll(listing.getObjectSummaries());
+            }
+
+            for (S3ObjectSummary file : files) {
                 String name = file.getKey().substring(folderKey.length());
                 if (name.matches("/\\d*/" + WORKSPACE_PROPERTIES_FILENAME)) {
                     long id = Long.parseLong(name.substring(1, name.lastIndexOf('/')));


### PR DESCRIPTION
AWS S3 API has a limit of maximum 1000 keys per response (reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html) - this breaks getWorkspaceIds when your have a lot of objects.

This pull request changes the way getWorkspaceIds method works when pulling objects from S3. 

Fixes #108 